### PR TITLE
Continue instead of crashing when objects are missing

### DIFF
--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -215,7 +215,9 @@ impl GitRepo {
             self.repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
         let mut files = Vec::new();
         for change in changes {
-            self.handle_change(change, binary, &mut files)?;
+            if let Err(err) = self.handle_change(change, binary, &mut files) {
+                eprintln!("Warning: {err}");
+            }
         }
 
         Ok(CommitStats {


### PR DESCRIPTION
This can happen with submodules.

Closes #3

Before:

```
Error: Failed to collect commits from repository

Caused by:
    0: Object find error: An object with id fdb30228b1dc649ab1c2086d146ef9dd0ab584e6 could not be found
    1: An object with id fdb30228b1dc649ab1c2086d146ef9dd0ab584e6 could not be found
```

After:

```
⠋ Collecting commits...                                                                                   Warning: Object find error: An object with id fdb30228b1dc649ab1c2086d146ef9dd0ab584e6 could not be found
⠦ Collecting commits...                                                                                   Warning: Object find error: An object with id fc412cbdf765175ea9f3380db6b9e1b1603a68a7 could not be found
⠤ Collecting commits...                                                                                   Warning: Object find error: An object with id b699a7e01c253ffb7818b02d62bce24190ec1019 could not be found
⠁ Collecting commits...                                                                                   Warning: Object find error: An object with id b699a7e01c253ffb7818b02d62bce24190ec1019 could not be found
  Commits collected
```

Not the prettiest, but better than a crash!